### PR TITLE
Add script to print RT Portal link

### DIFF
--- a/scripts/rt-portal.coffee
+++ b/scripts/rt-portal.coffee
@@ -1,0 +1,18 @@
+# Description:
+#   None
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   rt#0000 - Posts link to RT
+
+
+module.exports = (robot) ->
+  robot.hear /rt#\d+/ig, (res) ->
+    for match in res.match
+      parts = match.split "#"
+      res.send  "https://portal.admin.canonical.com/" + parts[1]


### PR DESCRIPTION
Fixes #5.

Links are expanded when the bot sees `rt#1234` style links.
