### PR TITLE
Add release notifications script

### DIFF
--- a/scripts/release-notifications.coffee
+++ b/scripts/release-notifications.coffee
@@ -48,7 +48,9 @@ module.exports = (robot) ->
       res.end ""
       return
 
-    message = "The webteam is autodeploying #{service_name} to production"
+    message = "" +
+      "The webteam is autodeploying #{service_name} to production. " +
+      "Contact us with @webteam or in #web-team"
 
     try
       for room in rooms


### PR DESCRIPTION
Announce releases to configured channels from a webhook

 - Created webhook for webbot at `/webbot/release-notification`.
 - Updated wendigo `deploy-to-production` script to ping webbot at the end. Currently pointing at webbot-dev.

The webhook takes a service name to use in the message, and a secret key to prevent unauthorised flooding.