### PR TITLE
Add status endpoint

### DIFF
--- a/scripts/status.coffee
+++ b/scripts/status.coffee
@@ -1,0 +1,10 @@
+# Description:
+#   An endpoint to check if the app is still alive
+#
+# URLS:
+#   GET /_status/check
+
+module.exports = (robot) ->
+  robot.router.get "/_status/check", (req, res) ->
+    res.send "ok"
+    res.end


### PR DESCRIPTION
# Summary

Add endpoint /_status/check for kubernetes to check if the pod is still alive

# QA

- After setting up all the env var (you can ask @tbille)
- `bin/hubot -a irc`
- Visit http://0.0.0.0:8080/_status/check
- Should get a 200 with "ok"
