### PR TITLE
Unpythonize coffeescript

### DIFF
--- a/scripts/pull-request-notifications.coffee
+++ b/scripts/pull-request-notifications.coffee
@@ -75,14 +75,14 @@ announcePullRequest = (data, cb) ->
 
     if data.pull_request.labels.length
       labels = data.pull_request.labels.map (label) ->
-          search = label.name.search /Review:/
-          if search != -1
-            labelres = label.name.toLowerCase()
-            labelres = labelres.replace /\ needed/, ""
+        search = label.name.search /Review:/
+        if search != -1
+          label.name.toLowerCase().replace /\ needed/, ""
             .replace /review: /, "review-"
 
-      labels_line = "\nLabels: #{labels.join(",")}"
-    else:
+      labels = labels.filter (x) -> typeof x == 'string'
+      labels_line = "Labels: #{labels.join(",")}"
+    else
       labels_line = ""
 
     cb "[webteam-newPR] New pull request \"#{data.pull_request.title}\" " +


### PR DESCRIPTION
Make labels work again after bad python code integration :P 


QA

https://www.jdoodle.com/compile-coffeescript-online/

```
data = {"pull_request": {
    "labels": [
        {
            "name": "test"
        },
        {
            "name": "Review: Code needed"
        },
        {
            "name": "Review: QA needed"
        },
    ]
}}

if data.pull_request.labels.length
  labels = data.pull_request.labels.map (label) ->
    search = label.name.search /Review:/
    if search != -1
      label.name.toLowerCase().replace /\ needed/, ""
        .replace /review: /, "review-"
  labels = labels.filter (x) -> typeof x == 'string'
  labels_line = "Labels: #{labels.join(",")}"
else
  labels_line = ""

console.log(labels_line)
```

You can test with this code

the result should be: `Labels: review-code,review-qa`