### PR TITLE
Add endpoint to publish message on gh action failure

### DIFF
--- a/scripts/github-action-notification.js
+++ b/scripts/github-action-notification.js
@@ -1,0 +1,53 @@
+/**
+*   Description:
+*   An HTTP Listener that notifies about new GitHub actions that fail
+*   Dependencies:
+*   "url": ""
+*   "querystring": ""
+*
+*   Commands:
+*   None
+*
+*   URLS:
+*   POST /hubot/gh-action-fail?room=<room>
+*       data:
+*           repo_name: The owner and repository name (GITHUB_REPOSITORY)
+*           action_id: The unique identifier (id) of the action (GITHUB_ACTION)
+*           workflow: Name of the workflow (GITHUB_WORKFLOW)
+*
+*   Authors:
+*   tbille
+*
+*   Notes:
+*   The data passed comes from https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+*   Room information can be obtained by hubot-script: room-info.coffee
+*   Room must be in url encoded format (i.e. encodeURIComponent("yourRoomInfo"))
+**/
+
+var querystring, url;
+
+url = require('url');
+querystring = require('querystring');
+
+module.exports = function(robot) {
+    return robot.router.post("/hubot/gh-action-fail", function(req, res) {
+        var action_id, data, error, query, repo_name, room, workflow;
+        query = querystring.parse(url.parse(req.url).query);
+        data = req.body;
+        repo_name = data.repo_name;
+        action_id = data.action_id;
+        workflow = data.workflow;
+
+        room = query.room;
+
+        try {
+            robot.messageRoom(room, "[webteam-action] 🛑 The action " + workflow + " failed: https://github.com/" + repo_name + "/runs/" + action_id);
+        } catch (_error) {
+            error = _error;
+            robot.messageRoom(room, "Whoa, I got an error: " + error);
+            console.log(("github action notifier error: " + error + ". ") + ("Request: " + req.body));
+        }
+
+        return res.end("");
+    });
+};


### PR DESCRIPTION
# Summary

Add endpoint to send message when github action fails:

` curl -X POST -F "workflow=<WORKFLOW>" -F "repo_name=<REPO_NAME>" -F "action_id=<ACTION_ID> <URL>/hubot/gh-action-fail\?room\=%23<ROOM>`

# QA

- Run bot (ask toto)
- ` curl -X POST -F "workflow=run-cypress" -F "repo_name=canonical-web-and-design/ubuntu.com" -F "action_id=457105239" http://localhost:8011/hubot/gh-action-fail\?room\=%23alsdkfj`

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6705