### PR TITLE
Fix documentation to remove annoying warnings

### DIFF
--- a/scripts/acronyms.js
+++ b/scripts/acronyms.js
@@ -1,3 +1,26 @@
+// Description:
+//   A human readable acronym translator that reads from a Google spreadsheet.
+//
+// Dependencies:
+//   google-spreadsheet: ""
+//
+// Configuration:
+//   set HUBOT_SPREADSHEET_ID in environment
+//   set HUBOT_SPREADSHEET_CLIENT_EMAIL in environment
+//   set HUBOT_SPREADSHEET_PRIVATE_KEY in environment
+//
+// Commands:
+//   hubot acronym <acronym>: translates the acronym to human readable words
+//
+// Note:
+//   The format of the spreadsheet should be:
+//
+//   | Acronym | Definition   | Link                                                                                              |
+//   | PR      | Pull-Request | https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests |
+//
+// Authors:
+//   tbille
+
 SPREADSHEET_ID = process.env.HUBOT_SPREADSHEET_ID;
 if (!SPREADSHEET_ID) {
     console.log("Missing SPREADSHEET_ID in environment");

--- a/scripts/github-action-notification.js
+++ b/scripts/github-action-notification.js
@@ -1,28 +1,24 @@
-/**
-*   Description:
-*   An HTTP Listener that notifies about new GitHub actions that fail
-*   Dependencies:
-*   "url": ""
-*   "querystring": ""
-*
-*   Commands:
-*   None
-*
-*   URLS:
-*   POST /hubot/gh-action-fail?room=<room>
-*       data:
-*           repo_name: The owner and repository name (GITHUB_REPOSITORY)
-*           action_id: The unique identifier (id) of the action (GITHUB_ACTION)
-*           workflow: Name of the workflow (GITHUB_WORKFLOW)
-*
-*   Authors:
-*   tbille
-*
-*   Notes:
-*   The data passed comes from https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-*   Room information can be obtained by hubot-script: room-info.coffee
-*   Room must be in url encoded format (i.e. encodeURIComponent("yourRoomInfo"))
-**/
+// Description:
+//   An HTTP Listener that notifies about new GitHub actions that fail
+//
+// Dependencies:
+//   url: ""
+//   querystring: ""
+//
+// URLS:
+//   POST /hubot/gh-action-fail?room=<room>
+//     data:
+//       repo_name: The owner and repository name (GITHUB_REPOSITORY)
+//       action_id: The unique identifier (id) of the action (GITHUB_ACTION)
+//       workflow: Name of the workflow (GITHUB_WORKFLOW)
+//
+// Notes:
+//   The data passed comes from https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+//   Room information can be obtained by hubot-script: room-info.coffee
+//   Room must be in url encoded format (i.e. encodeURIComponent("yourRoomInfo"))
+//
+// Authors:
+//   tbille
 
 var querystring, url;
 

--- a/scripts/toto.coffee
+++ b/scripts/toto.coffee
@@ -1,3 +1,15 @@
+# Description:
+#   A list of fun scripts.
+#
+# Commands:
+#   hubot toto: sends how many days toto has been cool
+#   hubot I love you: sends love
+#   hubot ask <person>: ask the person if it is live
+#   hubot words: sends 2 random words
+#
+# Author:
+#   tbille
+
 module.exports = (robot) ->
   robot.respond /toto/, (res) ->
     res


### PR DESCRIPTION
Remove documentation warning on start:
``` 
[Sun Mar 15 2020 13:39:42 GMT+0000 (Greenwich Mean Time)] INFO scripts/acronyms.js is using deprecated documentation syntax
[Sun Mar 15 2020 13:39:42 GMT+0000 (Greenwich Mean Time)] INFO scripts/github-action-notification.js is using deprecated documentation syntax
[Sun Mar 15 2020 13:39:42 GMT+0000 (Greenwich Mean Time)] INFO scripts/toto.coffee is using deprecated documentation syntax
````

For the `js` files I can't use the `/** ... **/` syntax because of this issue: https://github.com/hubotio/hubot/issues/1087#issuecomment-156626670

# QA

- `dotrun`
- No documentation warnings should be displayed.