### PR TITLE
Improve greeting reply

### DIFF
--- a/scripts/greetings.js
+++ b/scripts/greetings.js
@@ -67,7 +67,7 @@ module.exports = function(robot) {
         .split(" ")
         .some(word => robot.brain.usersForFuzzyName(word).length !== 0);
     }
-    if (!includesName) {
+    if (!includesName || remainder.includes(robot.name)) {
       // The user is probably not reciprocating another user's greeting so send
       // a reply.
       sendGreeting(res);
@@ -75,7 +75,7 @@ module.exports = function(robot) {
   });
 
   // Respond when someone says morning/night to webbot.
-  robot.respond(/^(goo+d )?(mo+rning|night)/i, function(res) {
+  robot.respond(/(goo+d )?(mo+rning|night)/i, function(res) {
     sendGreeting(res);
   });
 };


### PR DESCRIPTION
Done:
- Try to check if the user is replying to a greeting and if so don't send the greeting.
- Add international greetings.

QA:
- Run the shell with `dotrun`.
- Enter a greeting like "good morning" or "gooood night". You should get a reply, something like "good night Shell"
- Enter a greeting reply e.g. "night shell" (in this case we can only use our own name "Shell" as there are no other users in the shell channel). You should should not get a webbot reply.