### PR TITLE
Update to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # System dependencies
 RUN apt-get update && \
-    apt-get install libicu-dev nodejs npm git --yes
+    DEBIAN_FRONTEND=noninteractive apt-get install libicu-dev nodejs npm git --yes
 
 # Import code, install code dependencies
 WORKDIR /srv


### PR DESCRIPTION
I need to add `DEBIAN_FRONTEND=noninteractive` because of an error with [tzdata ](https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai)

Replace `AAAAAAAAAAAAAAAAAAAAAAAAAAAA` with the credentials of the bot
```
docker build --pull --tag irc . && docker run -d -e "HUBOT_AUTH_ADMIN=toto,deadlight,Peter,robin" -e "HUBOT_IRC_DEBUG=true" -e "HUBOT_IRC_NICK=totobot" -e "HUBOT_IRC_PASSWORD=AAAAAAAAAAAAAAAAAAAAAAAAAAAA" -e "HUBOT_IRC_PORT=6697" -e "HUBOT_IRC_ROOMS=#alsdkfj" -e "HUBOT_IRC_SERVER=irc.canonical.com" -e "HUBOT_IRC_USESSL=true" -e "HUBOT_RELEASE_NOTIFICATION_SECRET=gI5d4pIIaLRsSOv6" -e "HUBOT_RELEASE_NOTIFICATION_ROOMS=#sukha"
```
Talk to bot in  #alsdkfj