### PR TITLE
Use ubuntu image for node js build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM ubuntu:focal AS yarn-dependencies
 WORKDIR /srv
-RUN apt-get update && apt-get install git --yes
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install nodejs npm git --yes
 ADD package.json .
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/nmp npm install
 
 # Build the production image
 # ===

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM ubuntu:focal AS yarn-dependencies
 WORKDIR /srv
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install nodejs npm git --yes
 ADD package.json .
-RUN --mount=type=cache,target=/usr/local/share/.cache/nmp npm install
+RUN npm install -g yarn
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
 # Build the production image
 # ===


### PR DESCRIPTION
Use ubuntu image for the nodejs build step.

The reason is that at the moment the image is based on debian which is blocked at the moment from the proxy. We should revert that once it gets opened.

# qa

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag webbot . `
- `docker run -d -e "HUBOT_AUTH_ADMIN=totoy" -e "HUBOT_IRC_DEBUG=true" -e "HUBOT_IRC_NICK=totobot" -e "HUBOT_IRC_PASSWORD=###############PASSWORD" -e "HUBOT_IRC_PORT=6697" -e "HUBOT_IRC_ROOMS=#alsdkfj" -e "HUBOT_IRC_SERVER=irc.canonical.com" -e "HUBOT_IRC_USESSL=true" -e "HUBOT_RELEASE_NOTIFICATION_SECRET=######SECRET" -e "HUBOT_RELEASE_NOTIFICATION_ROOMS=#sukha" -p 8011:80 webbot`
- DOn't forget the change `###############PASSWORD`
- Check if bot connected to irc
