### PR TITLE
Add acronym endpoint for mattermost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install nodejs --yes
 # Import code, build assets and mirror list
 ADD . .
 RUN rm -rf package.json yarn.lock .babelrc webpack.config.js Gemfile Gemfile.lock nginx.conf
-COPY --from=yarn-dependencies srv/node_modules .
+COPY --from=yarn-dependencies srv/node_modules node_modules/
 
 ARG BUILD_ID
 

--- a/scripts/acronyms.js
+++ b/scripts/acronyms.js
@@ -8,9 +8,19 @@
 //   set HUBOT_SPREADSHEET_ID in environment
 //   set HUBOT_SPREADSHEET_CLIENT_EMAIL in environment
 //   set HUBOT_SPREADSHEET_PRIVATE_KEY in environment
+//   set MATTERMOST_TOKEN in environment
 //
 // Commands:
 //   hubot acronym <acronym>: translates the acronym to human readable words
+//
+// URLS:
+//   POST /hubot/acronym
+//     Follows format suggested here: https://docs.mattermost.com/developer/slash-commands.html
+//     data:
+//       token: Should be similar than MATTERMOST_TOKEN
+//       text: acronym
+//     response:
+//       {"response_type": "in_channel", "text": TEXT_POSTED}
 //
 // Note:
 //   The format of the spreadsheet should be:
@@ -21,17 +31,17 @@
 // Authors:
 //   tbille
 
-SPREADSHEET_ID = process.env.HUBOT_SPREADSHEET_ID;
+var SPREADSHEET_ID = process.env.HUBOT_SPREADSHEET_ID;
 if (!SPREADSHEET_ID) {
     console.log("Missing SPREADSHEET_ID in environment");
 }
 
-CLIENT_EMAIL = process.env.HUBOT_SPREADSHEET_CLIENT_EMAIL;
+var CLIENT_EMAIL = process.env.HUBOT_SPREADSHEET_CLIENT_EMAIL;
 if (!CLIENT_EMAIL) {
     console.log("Missing CLIENT_ID in environment");
 }
 
-PRIVATE_KEY = process.env.HUBOT_SPREADSHEET_PRIVATE_KEY;
+var PRIVATE_KEY = process.env.HUBOT_SPREADSHEET_PRIVATE_KEY;
 if (!PRIVATE_KEY) {
     console.log('Missing PRIVATE_KEY in environment');
 } else {
@@ -46,33 +56,56 @@ var CREDS = {
 const { GoogleSpreadsheet } = require('google-spreadsheet');
 const doc = new GoogleSpreadsheet(SPREADSHEET_ID);
 
-HTTPS_PROXY = process.env.HTTPS_PROXY;
+var HTTPS_PROXY = process.env.HTTPS_PROXY;
 if (HTTPS_PROXY) {
     doc.axios.defaults.proxy = false;
     const HttpsProxyAgent = require('https-proxy-agent');
     doc.axios.defaults.httpsAgent = new HttpsProxyAgent(HTTPS_PROXY);
 }
 
-async function googleSpreadsheetHandler(res) {
-    var acronym, acronyms;
-    acronym = res.match[1].toUpperCase().trim();
+var MATTERMOST_TOKEN = process.env.MATTERMOST_TOKEN;
+if (!MATTERMOST_TOKEN) {
+    console.log("Missing MATTERMOST_TOKEN in environment");
+}
 
+async function googleSpreadsheetHandler(acronym) {
+    var acronyms;
     await doc.useServiceAccountAuth(CREDS);
     await doc.loadInfo();
     const sheet = doc.sheetsByIndex[0];
-    rows = await sheet.getRows();
+    var rows = await sheet.getRows();
 
     var response = rows.filter(a => a.Acronym && a.Acronym.toUpperCase().trim() === acronym)[0];
 
     if (response) {
-        return res.send(response.Acronym + ': ' + response.Definition + ' ' + response.Link);
+        return response.Acronym + ': ' + response.Definition + ' ' + response.Link;
     } else {
-        return res.send('This acronym doens\'t exists (yet!)');
+        return `This acronym doens't exists (yet!). Add your own [here](https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID})`;
     }
 }
 
 module.exports = function(robot) {
-    robot.respond(/acronym (.*)/, function(res) {
-        googleSpreadsheetHandler(res);
+    robot.respond(/acronym (.*)/, async function(res) {
+        let acronym = res.match[1].toUpperCase().trim();
+        let result = await googleSpreadsheetHandler(acronym);
+        res.send(result);
+    });
+
+    robot.router.post("/hubot/acronym", async function(req, res) {
+        if (MATTERMOST_TOKEN != req.body.token) {
+            res.sendStatus(401);
+            return res.end("");
+        }
+
+        let result = `Format: \`/acronym <acronym>\` eg. \`/acronym usn\`. Add your own [here](https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID})`;
+        if (req.body.text) {
+            if (req.body.text.trim() != 'help') {
+                result = await googleSpreadsheetHandler(req.body.text.toUpperCase().trim());
+            }
+        }
+
+        res.setHeader('content-type', 'application/json');
+        res.send(JSON.stringify({"response_type": "in_channel", "text": result}));
+        return res.end("");
     });
 };


### PR DESCRIPTION
# Done

*This should be merged before deploy https://github.com/canonical-web-and-design/deployment-configs/pull/388*

Add endpoint to add slash command on mattermost.

The idea is to add the command `/acronym` to mattermost that will ping this endpoint with text and reply to which acronym it corresponds:
```
toto>/acronym USN
bot> USN: Ubuntu Security Notices https://usn.ubuntu.com/
```

For this I need to follow mattermost requirements: https://docs.mattermost.com/developer/slash-commands.html
- Add endpoint to post
- authentication with token
- return `{"response_type": "in_channel", "text": TEXT_POSTED}`

# QA

- Get credentials to be able to read on the acronym [spreadsheet](https://docs.google.com/spreadsheets/d/1nNk4typDnOfDEYRzlEjtd58zk-aOd3_NNp6eufthZHM/edit#gid=0) (ask @tbille )
- add those credentials in a file `.env.local`
- add in the same file the line: `MATTERMOST_TOKEN=test`
- in a terminal: `dotrun`
- in the prompt: `webbot acronym toto`
- you should have a response
- in another terminal: `curl --request POST  http://localhost:8080/hubot/acronym -H "Content-Type: application/x-www-form-urlencoded" -d "token=wrongsecret&text=toto"`
- It should 401
- now : `curl --request POST  http://localhost:8080/hubot/acronym -H "Content-Type: application/x-www-form-urlencoded" -d "token=test&text=toto"`
- Should return: `{"response_type":"in_channel","text":"Toto: Totally obscure terrestrial organism https://www.youtube.com/watch?v=oHg5SJYRHA0"}`
- finally : `curl --request POST  http://localhost:8080/hubot/acronym -H "Content-Type: application/x-www-form-urlencoded" -d "token=test&text="`
- `{"response_type":"in_channel","text":"Format: /acronym <acronym>"}`