### PR TITLE
Add repo name on pull request notification

### DIFF
--- a/scripts/pull-request-notifications.coffee
+++ b/scripts/pull-request-notifications.coffee
@@ -85,6 +85,6 @@ announcePullRequest = (data, cb) ->
     else
       labels_line = ""
 
-    cb "[webteam-newPR] New pull request [\"#{data.pull_request.title}\"](#{data.pull_request.html_url}) " +
+    cb "[webteam-newPR] New pull request on #{data.repository.full_name}: [\"#{data.pull_request.title}\"](#{data.pull_request.html_url}) " +
       "by #{data.pull_request.user.login}: " +
       "#{mentioned_line} #{labels_line}"


### PR DESCRIPTION
Add repo name to get instant understanding what repo the pull request comes from

You can check that the payload sent by github follows the right path: `data.repository.full_name` (https://github.com/organizations/canonical-web-and-design/settings/hooks/230769442)