### PR TITLE
Link to engage page discourse page

### DIFF
--- a/scripts/engage-page-notifications.js
+++ b/scripts/engage-page-notifications.js
@@ -55,10 +55,10 @@ module.exports = async function(robot) {
         }
 
         var rooms = query.rooms.split(',');
-        var { title, slug, created_by } = data.topic;
+        var { id, title, slug, created_by } = data.topic;
         var authorName = created_by.name || created_by.username;
-        var pageURL = "https://ubuntu.com/engage/" + slug;
-        var message = "New engage page ['" + title + "'](" + pageURL + ") created by " + authorName;
+        var topicURL = req.headers["x-discourse-instance"] + "/t/" + slug + "/" + id;
+        var message = "New engage page ['" + title + "'](" + topicURL + ") created by " + authorName;
 
         await sendMessages(robot, rooms, message);
 


### PR DESCRIPTION
We can't accuratly build the link to the page in ubuntu.com so we link to discourse instead.