### PR TITLE
Add alerting from grafana

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,5 @@ MATTERMOST_HOST=chat.canonical.com
 MATTERMOST_GROUP=canonical
 MATTERMOST_USER=webbot
 MATTERMOST_TOKEN=test_token
+GRAFANA_USERNAME=test_username
+GRAFANA_PASSWORD=test_password

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -53,3 +53,11 @@ env:
     secretKeyRef:
       key: discourse-webhook-secret
       name: irc-secrets
+  - name: GRAFANA_USERNAME
+    secretKeyRef:
+      key: grafana-username
+      name: irc-secrets
+  - name: GRAFANA_PASSWORD
+    secretKeyRef:
+      key: grafana-password
+      name: irc-secrets

--- a/scripts/alert.js
+++ b/scripts/alert.js
@@ -1,0 +1,57 @@
+// Description:
+//   An HTTP Listener that notifies about alert from Grafana
+//
+// Dependencies:
+//   url: ""
+//   querystring: ""
+//
+// Configuration:
+//   set GRAFANA_USERNAME in environment
+//   set GRAFANA_PASSWORD in environment
+//
+// URLS:
+//   POST /hubot/grafana-alert?room=<room>
+//   header:
+//     Basic authentication that has username and password
+//
+// Authors:
+//   tbille
+
+var querystring, url;
+
+url = require('url');
+querystring = require('querystring');
+
+var user = process.env.GRAFANA_USERNAME;
+var pass = process.env.GRAFANA_PASSWORD;
+var auth = 'Basic ' + Buffer.from(user + ':' + pass).toString('base64');
+
+module.exports = function(robot) {
+    return robot.router.post("/hubot/grafana-alert", function(req, res) {
+        if (req.headers['authorization'] !== auth) {
+            res.status(403);
+            res.send("Invalid secret");
+            return res.end("");
+        }
+
+        let query = querystring.parse(url.parse(req.url).query);
+        let room = query.room;
+        if (!room) {
+            res.status(400);
+            res.send("Parameters rooms required");
+            return res.end("");
+        }
+
+        let data = req.body;
+        let message = `[webteam-alert] 🚨 [${data["ruleName"]}](${data["ruleUrl"]}): ${data["message"]}`;
+
+        try {
+            robot.messageRoom(room, message);
+        } catch (_error) {
+            robot.messageRoom(room, "Whoa, I got an error: " + _error);
+            console.log(("grafana alert notifier error: " + _error + ". ") + ("Request: " + req.body));
+        }
+
+        return res.end("");
+    });
+};


### PR DESCRIPTION
# Done

- Add alerting script from grafana to mattermost
- This will handle alerts received from grafana (set by us) and send a message to matttermost
- The objective is to set a list of alerts that we are interested in and get notifications on our channel (before IS :P )
- The message posted will give a link to the graph that generated the alert

# QA

- `dotrun`
- Use [ngrok](https://ngrok.com/): `ngrok 8080`
- On grafana create a notification channel ([here for ours](https://kpi.canonical.com/webteam/alerting/notifications))
- The values should be:
```
Name: Test alert
Type: webhook
Url: <NGROK URL>/hubot/grafana-alert?room=webteam

Optional Webhook settings:
Http Method: POST
Username: test_username
Password: test_password
```
- Press `Test`
- On your console you should see a message like this:
```
[webteam-alert] 🚨 [Test notification](https://kpi.canonical.com/webteam/): Someone is testing the alert notification within Grafana.
```
- Try with another password
- Make sure it's not working