### PR TITLE
Add custom_message query param to github-action-notification

### DIFF
--- a/scripts/github-action-notification.js
+++ b/scripts/github-action-notification.js
@@ -6,7 +6,7 @@
 //   querystring: ""
 //
 // URLS:
-//   POST /hubot/gh-action-fail?room=<room>
+//   POST /hubot/gh-action-fail?room=<room>&custom_message=<message>
 //     data:
 //       repo_name: The owner and repository name (GITHUB_REPOSITORY)
 //       action_id: The unique identifier (id) of the action (GITHUB_ACTION)
@@ -16,6 +16,8 @@
 //   The data passed comes from https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 //   Room information can be obtained by hubot-script: room-info.coffee
 //   Room must be in url encoded format (i.e. encodeURIComponent("yourRoomInfo"))
+//
+//   (Optional) custom_message: will override the default message.
 //
 // Authors:
 //   tbille
@@ -27,7 +29,7 @@ querystring = require('querystring');
 
 module.exports = function(robot) {
     return robot.router.post("/hubot/gh-action-fail", function(req, res) {
-        var action_id, data, error, query, repo_name, room, workflow;
+        var action_id, data, error, query, repo_name, room, workflow, message;
         query = querystring.parse(url.parse(req.url).query);
         data = req.body;
         repo_name = data.repo_name;
@@ -36,8 +38,13 @@ module.exports = function(robot) {
 
         room = query.room;
 
+        message = "[webteam-action] 🛑 The action ['" + workflow + "' failed](https://github.com/" + repo_name + "/actions/runs/" + action_id + ")";
+        if (query.custom_message) {
+          message = "[webteam-action] 🛑 " + query.custom_message;
+        }
+
         try {
-            robot.messageRoom(room, "[webteam-action] 🛑 The action ['" + workflow + "' failed](https://github.com/" + repo_name + "/actions/runs/" + action_id + ")");
+            robot.messageRoom(room, message);
         } catch (_error) {
             error = _error;
             robot.messageRoom(room, "Whoa, I got an error: " + error);


### PR DESCRIPTION
## Done
Add optional `custom_message` parameter to the github-action-notification script

## QA
I am struggling to get this to work locally. Running `dotrun` results configs reported missing and no commands working.
