### PR TITLE
add debug log for the explain 401

### DIFF
--- a/scripts/explain.js
+++ b/scripts/explain.js
@@ -117,6 +117,7 @@ module.exports = function (robot) {
   });
 
   robot.router.post("/hubot/explain", async function (req, res) {
+    console.log("debug /explain:", req.body.token);
     if (MATTERMOST_TOKEN_CMD_EXPLAIN != req.body.token) {
       res.sendStatus(401);
       return res.end("");


### PR DESCRIPTION
## Done

- add a temporary log to debug the /explain command that is failing, for more info see this [IS ticket](https://github.com/canonical-web-and-design/webteam-hubot/compare/debug-exaplain-command?expand=1)

