### PR TITLE
Fix explain command table

### DIFF
--- a/scripts/explain.js
+++ b/scripts/explain.js
@@ -94,11 +94,11 @@ async function googleSpreadsheetHandler(explain) {
     );
     let text = "";
     responses.forEach(function (response) {
-      const link = response.Link ? response.Link : "";
+      const link = (response.Link && response.Link !== "N/A") ? response.Link : "";
       const definition = response.Definition ? response.Definition.replace(/[\r\n]/gm, ' ') : "";
-      const MM_Channel = response.Contact ? response.Contact : "";
-      const PM = response.PM ? response.PM : "";
-      const team = response.Team ? response.Team : "";
+      const MM_Channel = (response.Contact && response.Contact !== "N/A" ) ? response.Contact : "";
+      const PM = (response.PM && response.PM !== "N/A") ? response.PM : "";
+      const team = (response.Team && response.Team !== "N/A") ? response.Team : "";
       text += `| ${response.Explain} | ${definition} |`
       PM && (text += `\n | PM | ${PM} |`)
       team && (text += `\n | Team | ${team} |`)

--- a/scripts/explain.js
+++ b/scripts/explain.js
@@ -95,17 +95,15 @@ async function googleSpreadsheetHandler(explain) {
     let text = "";
     responses.forEach(function (response) {
       const link = response.Link ? response.Link : "";
-      const definition = response.Definition ? response.Definition : "";
+      const definition = response.Definition ? response.Definition.replace(/[\r\n]/gm, ' ') : "";
       const MM_Channel = response.Contact ? response.Contact : "";
       const PM = response.PM ? response.PM : "";
       const team = response.Team ? response.Team : "";
-      text = `| | |
-|--|--|
-| ${response.Explain} | ${definition} |
-| PM | ${PM} |
-| Team | ${team} |
-| Contact channel | ${MM_Channel} |
-| Read more | ${link} |`;
+      text += `| ${response.Explain} | ${definition} |`
+      PM && (text += `\n | PM | ${PM} |`)
+      team && (text += `\n | Team | ${team} |`)
+      MM_Channel && (text += `\n | Contact channel | ${MM_Channel} |`)
+      link && (text += `\n | Read more | ${link} |`)
     });
 
     if (text) {


### PR DESCRIPTION
## Done
- Remove empty row at the top in explain command table.
- Hide rows that don't have values. 
- Fix table broken when there are multiple lines in spreadsheet cell


## QA

- e.g. `/explain Figma` on mattermost and check the table looks good
- You can QA by adding lines on spreadsheet cells and check the output. 
- Please check all these three issues below are solved. 

## Issue 

Fixes #150 #151 #152 