### PR TITLE
add an empty header to be a valid table MD syntax

### DIFF
--- a/scripts/explain.js
+++ b/scripts/explain.js
@@ -92,7 +92,7 @@ async function googleSpreadsheetHandler(explain) {
     const responses = rows.filter(
       (a) => a.Explain && a.Explain.toUpperCase().trim() === explain
     );
-    let text = "";
+    let text = "| | |\n|--|--|\n";
     responses.forEach(function (response) {
       const link = (response.Link && response.Link !== "N/A") ? response.Link : "";
       const definition = response.Definition ? response.Definition.replace(/[\r\n]/gm, ' ') : "";


### PR DESCRIPTION
## Done

- Add an empty header so that Mattermost display the output as a table

## QA

- Make sure that you have the secret `HUBOT_SPREADSHEET_PRIVATE_KEY` in your `.env.local` (feel free to contact me if needed)
- Run the project: `dotrun`
- Run the command twice (the first fails): `webbot explain what`
- Copy/paste the output to a random place at mattermost
- Make sure that the output is a table

## Screenshots

### Before 😒
![image](https://user-images.githubusercontent.com/36013798/173836268-28c270b8-68b6-44de-b0b4-7452105e5fbb.png)

### After 😏
![image](https://user-images.githubusercontent.com/36013798/173836352-1ccf9667-0af9-45d6-9f73-d139231f6857.png)

