### PR TITLE
Added jenkins job status responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Here is the list of great scripts that `webbot` provides:
 - `github-action-notifier.js`: an endpoint to notify a IRC channel that a GitHub Action as failed
 - `pull-request-notifications.coffee`: an endpoint that listens to webhooks from GitHub and publishes a message on IRC on new pull-requests
 - `release-notifications.coffee`: an endpoint to notify a given channel when a site gets released
+- `jenkins-job-status.js`: an endpoint to return the status of a job's last build on jenkins
 - `rt-portal.coffee`: rt#NUMBER to a clickable link
 - `status.coffee`: an endpoint that returns OK
 - `toto.coffee`: fun scripts

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -29,6 +29,14 @@ env:
     secretKeyRef:
       key: hubot-auth-admin
       name: irc-secrets
+  - name: JENKINS_URL
+    secretKeyRef:
+      key: jenkins-url
+      name: webteam-jenkins
+  - name: JENKINS_TOKEN
+    secretKeyRef:
+      key: jenkins-token
+      name: webteam-jenkins
   - name: MATTERMOST_ACCESS_TOKEN
     secretKeyRef:
       key: mattermost-access-token

--- a/scripts/jenkins-job-status.js
+++ b/scripts/jenkins-job-status.js
@@ -29,34 +29,35 @@ module.exports = async function (robot) {
   const echoJobStatus = (room, jobName, job_id) => {
     let url_params = `token=${JENKINS_TOKEN}`;
     job_id = job_id || "lastBuild";
-    let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/api/json?${url_params}`;
+    let job_json_url = `http://${JENKINS_URL}/webteam/job/${jobName}/${job_id}/api/json?${url_params}`;
 
     // Fetch the status of the job from Jenkins
     fetch(job_json_url).then((response) => {
       if (response.ok) {
         let data = response.json();
         if (data.result === "FAILURE") {
-          robot.messageRoom(
-            room,
+          let message =
             "[webteam-jenkins] ❌ Jenkins job '" +
-              jobName +
-              "' failed." +
-              `You can check the logs at ${data.url}` +
-              "/console"
-          );
+            jobName +
+            "' failed." +
+            `You can check the logs at ${data.url}` +
+            "/console";
+          res.send(message);
+          robot.messageRoom(room, message);
         } else if (data.result === "SUCCESS") {
-          robot.messageRoom(
-            room,
-            "[webteam-jenkins] ✅ Jenkins job '" + jobName + "' succeeded."
-          );
+          let message =
+            "[webteam-jenkins] ✅ Jenkins job '" + jobName + "' succeeded.";
+          res.send(message);
+          robot.messageRoom(room, message);
         } else {
-          robot.messageRoom(
+          let message =
             "[webteam-jenkins] 🛠️ Jenkins job '" +
-              jobName +
-              "' is still building." +
-              `You can check the logs at ${data.url}` +
-              "/console"
-          );
+            jobName +
+            "' is still building." +
+            `You can check the logs at ${data.url}` +
+            "/console";
+          res.send(message);
+          robot.messageRoom(message);
         }
         return res.end("");
       } else {

--- a/scripts/jenkins-job-status.js
+++ b/scripts/jenkins-job-status.js
@@ -27,9 +27,9 @@ querystring = require("querystring");
 
 module.exports = async function (robot) {
   const echoJobStatus = (room, jobName, job_id) => {
+    let url_params = `token=${JENKINS_TOKEN}`;
     job_id = job_id || "lastBuild";
     let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/api/json?${url_params}`;
-    let url_params = `token=${JENKINS_TOKEN}`;
 
     // Fetch the status of the job from Jenkins
     fetch(job_json_url).then((response) => {

--- a/scripts/jenkins-job-status.js
+++ b/scripts/jenkins-job-status.js
@@ -19,15 +19,15 @@
 
 const JENKINS_TOKEN = process.env.JENKINS_SECRET;
 const JENKINS_URL = process.env.JENKINS_URL;
-
-var querystring, fetch;
+const HUBOT_RELEASE_NOTIFICATION_SECRET =
+  process.env.HUBOT_RELEASE_NOTIFICATION_SECRET;
 
 fetch = require("node-fetch");
 querystring = require("querystring");
 
 module.exports = async function (robot) {
   const echoJobStatus = (room, jobName, job_id) => {
-    let job_id = job_id || "lastBuild";
+    job_id = job_id || "lastBuild";
     let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/api/json?${url_params}`;
     let url_params = `token=${JENKINS_TOKEN}`;
 
@@ -70,7 +70,7 @@ module.exports = async function (robot) {
   };
 
   const echoJobLogs = (room, jobName, job_id) => {
-    let job_id = job_id || "lastBuild";
+    job_id = job_id || "lastBuild";
     let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/consoleText?${url_params}`;
     let url_params = `token=${JENKINS_TOKEN}`;
 
@@ -129,6 +129,13 @@ module.exports = async function (robot) {
     let data = req.body;
     let jenkins_job = data.jenkins_job;
     let job_id = data.job_id;
+    let secret = data.secret;
+
+    if (secret != HUBOT_RELEASE_NOTIFICATION_SECRET) {
+      res.send("Invalid secret");
+      res.end("");
+      return;
+    }
 
     // Post the status to the webteam-job-status room
     echoJobStatus("webteam-job-status", jenkins_job, job_id);

--- a/scripts/jenkins-job-status.js
+++ b/scripts/jenkins-job-status.js
@@ -1,0 +1,137 @@
+// Description:
+//   An HTTP Listener that notifies about job statuses on Jenkins
+//
+// Dependencies:
+//   jobName: ""
+//
+// URLS:
+//   POST /hubot/jenkins-job-status?jobName=<job>
+//     data:
+//       jenkins_job_status: The status message from Jenkins
+// Notes:
+//   The data passed comes from Jenkins jobs.
+//
+//   You can query a job's status by using the following command:
+//   webbot job status <jobName>
+//
+// Authors:
+//   sam-olwe
+
+const JENKINS_TOKEN = process.env.JENKINS_SECRET;
+const JENKINS_URL = process.env.JENKINS_URL;
+
+var querystring, fetch;
+
+fetch = require("node-fetch");
+querystring = require("querystring");
+
+module.exports = async function (robot) {
+  const echoJobStatus = (room, jobName, job_id) => {
+    let job_id = job_id || "lastBuild";
+    let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/api/json?${url_params}`;
+    let url_params = `token=${JENKINS_TOKEN}`;
+
+    // Fetch the status of the job from Jenkins
+    fetch(job_json_url).then((response) => {
+      if (response.ok) {
+        let data = response.json();
+        if (data.result === "FAILURE") {
+          robot.messageRoom(
+            room,
+            "[webteam-jenkins] ❌ Jenkins job '" +
+              jobName +
+              "' failed." +
+              `You can check the logs at ${data.url}` +
+              "/console"
+          );
+        } else if (data.result === "SUCCESS") {
+          robot.messageRoom(
+            room,
+            "[webteam-jenkins] ✅ Jenkins job '" + jobName + "' succeeded."
+          );
+        } else {
+          robot.messageRoom(
+            "[webteam-jenkins] 🛠️ Jenkins job '" +
+              jobName +
+              "' is still building." +
+              `You can check the logs at ${data.url}` +
+              "/console"
+          );
+        }
+        return res.end("");
+      } else {
+        robot.messageRoom(room, "Status couldn't be retrieved: " + err);
+        console.log(
+          "Jenkins job status error: " + err + ". " + ("Request: " + req.body)
+        );
+        return res.end("");
+      }
+    });
+  };
+
+  const echoJobLogs = (room, jobName, job_id) => {
+    let job_id = job_id || "lastBuild";
+    let job_json_url = `http://${JENKINS_URL}/job/${jobName}/${job_id}/consoleText?${url_params}`;
+    let url_params = `token=${JENKINS_TOKEN}`;
+
+    // Fetch the job's logs from Jenkins
+    fetch(job_json_url).then((response) => {
+      if (response.ok) {
+        robot.messageRoom(
+          room,
+          `[webteam-jenkins] 🛠️ Logs for Jenkins job ${jobName}'` +
+            "\n" +
+            "======================" +
+            "\n" +
+            response.text()
+        );
+        return res.end("");
+      } else {
+        robot.messageRoom(
+          room,
+          `Logs for job ${jobName} couldn't be retrieved: ` + err
+        );
+        console.log(
+          "Jenkins job status error: " + err + ". " + ("Request: " + req.body)
+        );
+        return res.end("");
+      }
+    });
+  };
+
+  // Respond to:
+  // webbot job status <jobName>
+  // webbot job status <jobName> <job_id>
+  robot.respond(/webbot job status\s?(\w)*\s?(\d){1,6}/i, async function (res) {
+    const jobName = res.match[1];
+    let job_id = res.match[2];
+
+    const room = res.message.room;
+    if (["Shell", "webteam-job-status"].includes(room)) {
+      echoJobStatus(room, jobName, job_id);
+    }
+  });
+
+  // Respond to:
+  // webbot job logs <jobName>
+  // webbot job logs <jobName> <job_id>
+  robot.respond(/webbot job logs\s?(\w)*\s?(\d){1,6}/i, async function (res) {
+    const jobName = res.match[1];
+    let job_id = res.match[2];
+
+    const room = res.message.room;
+    if (["Shell", "webteam-job-status"].includes(room)) {
+      echoJobLogs(room, jobName, job_id);
+    }
+  });
+
+  robot.router.post("/hubot/report-jenkins-job-status", function (req, res) {
+    let data = req.body;
+    let jenkins_job = data.jenkins_job;
+    let job_id = data.job_id;
+
+    // Post the status to the webteam-job-status room
+    echoJobStatus("webteam-job-status", jenkins_job, job_id);
+    return res.end("");
+  });
+};


### PR DESCRIPTION
## Done
- Added a new path to be used to report jenkins job statuses at `/hubot/report-jenkins-job-status` 
e.g
```bash
curl -X POST -F "jenkins_job=debug-test-job" F "secret=secret" https://webteam-ircbot.canonical.com/hubot/report-jenkins-job-status
```
Which updates the job status in the `webteam-job-status` channel.

- Added mattermost responders for
```
webbot job logs jobName <jobid>
webbot job status jobName <jobid>
```